### PR TITLE
Make PostHog.Sender a pool

### DIFF
--- a/lib/posthog/registry.ex
+++ b/lib/posthog/registry.ex
@@ -13,4 +13,7 @@ defmodule PostHog.Registry do
 
   def via(supervisor_name, server_name),
     do: {:via, Registry, {registry_name(supervisor_name), server_name}}
+
+  def via(supervisor_name, pool_name, index),
+    do: {:via, Registry, {registry_name(supervisor_name), {pool_name, index}}}
 end

--- a/lib/posthog/sender.ex
+++ b/lib/posthog/sender.ex
@@ -94,6 +94,10 @@ defmodule PostHog.Sender do
 
   @impl GenServer
   def handle_continue(:send_batch, state) do
+    # Before we initiate an HTTP request that might block the process
+    # for a potentially noticeable time, we signal to the outside world that this
+    # sender is currently busy and if there is another sender available it
+    # should be used instead.
     Registry.update_value(state.registry, registry_key(state.index), fn _ -> :busy end)
     PostHog.API.post_batch(state.api_client, state.events)
     Registry.update_value(state.registry, registry_key(state.index), fn _ -> :available end)


### PR DESCRIPTION
This PR introduces sender pooling. 

The implementation is fairly simple. `PostHog.Supervisor` will start a `PostHog.Sender` genserver for each scheduler (but minimum 2). Those sender register themselves in the registry under `{PostHog.Sender, <index_name>}` name. Additionally, they would set their "value" in registry to `:available`. Whenever they attempt to actually send a batch of events, they would update this value to `:busy` until the request is done. This is to accommodate for potentially long API request, especially if we account for `Req`'s default [retry](https://hexdocs.pm/req/Req.Steps.html#retry/1) logic. 

Whenever client processes call `PostHog.Sender.send`, they would fetch all senders' pids from registry, pick the one that is available and send event to them. If there are no available processes, a random busy one is chosen.